### PR TITLE
Socket fix for market data

### DIFF
--- a/private/common.go
+++ b/private/common.go
@@ -30,7 +30,7 @@ func (p *Private) post(endpoint string, data interface{}) ([]byte, error) {
 }
 
 func (p *Private) delete(endpoint string, params url.Values) ([]byte, error) {
-	return p.request(http.MethodGet, helpers.GenerateQueryPath(endpoint, params), "")
+	return p.request(http.MethodDelete, helpers.GenerateQueryPath(endpoint, params), "")
 }
 
 func (p *Private) request(method, endpoint string, data string) ([]byte, error) {

--- a/realtime/connect.go
+++ b/realtime/connect.go
@@ -206,9 +206,18 @@ RESTART:
 				}
 
 			case MARKETS:
-				if err := json.Unmarshal(data, &res.Markets); err != nil {
-					l.Printf("[WARN]: cant unmarshal orderbook %+v", err)
+				if err := json.Unmarshal([]byte(data), &res.Markets); err != nil {
+					l.Printf("[WARN]: cant unmarshal markets %+v", err)
 					continue
+				}
+				// handle case where market data response if keys differently in json payload after inital connection
+				if len(res.Markets.Markets) == 0 {
+					var marketData map[string]public.Market
+					if err := json.Unmarshal([]byte(data), &marketData); err != nil {
+						l.Printf("[WARN]: cant unmarshal markets %+v", err)
+						continue
+					}
+					res.Markets.Markets = marketData
 				}
 
 			case TRADES:


### PR DESCRIPTION
DyDX API for some reason has different objects for initial market data response and subsequent meaning that this client library can only handle market data on initial websocket connection.

Updating market data websocket connection code to handle market data in the format returned from DYDX API 

